### PR TITLE
Hass 2024.11 update progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+![GitHub Release](https://img.shields.io/github/v/release/Domochip/WPalaSensor)
+![Home Assistant](https://img.shields.io/badge/home_assistant-2024.11-blue.svg?logo=homeassistant)
+
 # WPalaSensor
 
 This project aims to replace the Palazzetti (Fumis) room temperature sensor by an electronic simulator.  

--- a/src/WPalaSensor.cpp
+++ b/src/WPalaSensor.cpp
@@ -439,14 +439,14 @@ void WPalaSensor::mqttCallback(char *topic, uint8_t *payload, unsigned int lengt
       // Define the progress callback function
       std::function<void(size_t, size_t)> progressCallback = [this, &resTopic, &lastProgressPublish](size_t progress, size_t total)
       {
-        // if last progress publish is less than 1 second ago then return
-        if (millis() - lastProgressPublish < 1000)
+        // if last progress publish is less than 500ms ago then return
+        if (millis() - lastProgressPublish < 500)
           return;
         lastProgressPublish = millis();
 
         uint8_t percent = (progress * 100) / total;
         LOG_SERIAL_PRINTF_P(PSTR("Progress: %d%%\n"), percent);
-        String payload = String(F("{\"progress\":\"")) + percent + F("%\"}");
+        String payload = String(F("{\"update_percentage\":")) + percent + '}';
         _mqttMan.publish(resTopic.c_str(), payload.c_str(), true);
       };
 
@@ -454,9 +454,12 @@ void WPalaSensor::mqttCallback(char *topic, uint8_t *payload, unsigned int lengt
     }
 
     if (SystemState::shouldReboot)
-      retMsg = F("{\"progress\":\"Update successful\"}");
+      retMsg = F("{\"update_percentage\":null,\"in_progress\":true}");
     else
-      retMsg = String(F("{\"progress\":\"Update failed: ")) + retMsg + F("\"}");
+    {
+      _mqttMan.publish(topic, (String(F("Update failed: ")) + retMsg).c_str(), true);
+      retMsg = F("{\"in_progress\":false}");
+    }
 
     // publish result
     _mqttMan.publish(resTopic.c_str(), retMsg.c_str(), true);
@@ -641,8 +644,16 @@ bool WPalaSensor::mqttPublishUpdate()
     }
   }
 
-  // publish update info
+  // calculate topic
   topic = baseTopic + F("update");
+
+  // publish install in_progress (new in 2024.11)
+  // I keep it here because I want to separate the two publish for retrocompatibility
+  // if "in_progress" is in the same payload, Home Assistant 2024.10 and lower will ignore the payload
+  // (to be moved to WBase around 2025-05)
+  _mqttMan.publish(topic.c_str(), (String(F("{\"in_progress\":")) + (Update.isRunning() ? F("true") : F("false")) + '}').c_str(), true);
+
+  // publish update info
   _mqttMan.publish(topic.c_str(), updateInfo.c_str(), true);
 
   return true;


### PR DESCRIPTION
Online Update triggered via Home Assistant Update entity now displays the progress.
Home Assistant 2024.11 minimum is required to see it